### PR TITLE
fix: el was not defined,  changed to containerEl

### DIFF
--- a/assets/easy_points_integration.js
+++ b/assets/easy_points_integration.js
@@ -184,7 +184,7 @@ var EasyPoints = {
             totalPoints = parseInt(node.textContent.replace(/\D/g, ''));
           }
 
-          totalPoints += Math.round(EasyPoints.Points.getTotalBonusPoints(el));
+          totalPoints += Math.round(EasyPoints.Points.getTotalBonusPoints(containerEl));
           insertPointValueIntoElement(node, totalPoints);
         });
     },


### PR DESCRIPTION
While going through an integration, I encountered this error.

<img width="1245" alt="Screen Shot 2022-08-02 at 16 45 40" src="https://user-images.githubusercontent.com/84076465/182335571-5149b33e-1c9b-4e1d-a33a-6e849dff0560.png">

It was solved when I changed the **el** to **containerEl**

<img width="2023" alt="Screen Shot 2022-08-02 at 14 40 20" src="https://user-images.githubusercontent.com/84076465/182335634-38a3cfed-eb98-4f09-a382-4c77eca691a1.png">