### PR TITLE
Remove hardcoded values

### DIFF
--- a/assets/easy_points.js
+++ b/assets/easy_points.js
@@ -1,3 +1,14 @@
+const POINT_RATIO = 1.0;
+
+function getMultiplier() {
+  if (!window.EasyPointsData) {
+    throw new Error('missing loyalty data, make sure required liquid is rendered.');
+  }
+
+  return window.EasyPointsData.shop.multiplier * EasyPointsCore.Currency.getRate();
+}
+
+
 function formatBigNumber(int) {
   return int.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
@@ -5,7 +16,7 @@ function formatBigNumber(int) {
 function insertPointValue(ele) {
   var currencyCostString = ele.getAttribute("data-loyal-currency-cost");
   var regex = /[^\d]/g;
-  var currencyCost = currencyCostString.replace(regex, "") / (100 * EasyPointsCore.Currency.getRate());
+  var currencyCost = currencyCostString.replace(regex, "") / getMultiplier();
 
   var points = currencyCost * pointRulePercent;
 
@@ -174,13 +185,8 @@ function updateDiscountInfo() {
 }
 
 function displayDiscount(value) {
-  var currencyValue = "¥";
-  var currencyRatio = "1.0";
-  currencyValue += formatBigNumber(value / currencyRatio).toString();
-
   var easyPointsSession = getEasyPointsSession();
   easyPointsSession.appliedDiscount = value;
-  easyPointsSession.appliedDiscountCurrency = currencyValue;
   setEasyPointsSession(easyPointsSession);
 
   displayAppliedDiscount();
@@ -357,8 +363,8 @@ var EasyPointsCore = {
         max = parseInt(pointsMaxEl.value);
       }
 
-      max = max / (100 * EasyPointsCore.Currency.getRate());
-      max *= 1.0;
+      max = max / getMultiplier();
+      max *= POINT_RATIO;
       max = Math.floor(max);
 
       return 0 < points && points <= Math.min(balance, max);
@@ -391,14 +397,15 @@ var EasyPointsCore = {
       var nextTier =
         rankAdvancementData.tiers
           .find((tier) => {
-            return (tier.raw_amount * (100 * EasyPointsCore.Currency.getRate())) > subtotal;
+            var diff = (tier.raw_amount * getMultiplier()) - subtotal;
+            return Math.max(diff, 0) > 0;
           });
 
       if (nextTier) {
         return {
           name: nextTier.name,
           advancementAmountRaw: nextTier.raw_amount,
-          advancementAmountMultiplied: (nextTier.raw_amount * (100 * EasyPointsCore.Currency.getRate())) - subtotal,
+          advancementAmountMultiplied: (nextTier.raw_amount * getMultiplier()) - subtotal,
         }
       }
 
@@ -754,7 +761,7 @@ window.addEventListener('DOMContentLoaded', function() {
 
     document.querySelectorAll('[data-loyal-target="point-value"]:not([data-loyal-block])')
       .forEach(function(ele) {
-        var currencyCost = parseInt(ele.dataset.loyalCurrencyCost) / (100 * EasyPointsCore.Currency.getRate());
+        var currencyCost = parseInt(ele.dataset.loyalCurrencyCost) / getMultiplier();
         var points = currencyCost * (pointValue / currencyValue);
         var target = ele.querySelector('[data-loyal-target="point-value-location"]');
 
@@ -798,10 +805,8 @@ window.addEventListener('DOMContentLoaded', function() {
 
             if (typeof resp.coupon_value === "number" && resp.coupon_value > 0) {
               easyPointsSession.appliedDiscount = resp.coupon_value;
-              easyPointsSession.appliedDiscountCurrency = resp.coupon_currency;
             } else {
               delete easyPointsSession.appliedDiscount;
-              delete easyPointsSession.appliedDiscountCurrency;
             }
 
             easyPointsSession.customerMetafieldUpdatedAt = new Date();

--- a/assets/easy_points.js
+++ b/assets/easy_points.js
@@ -8,7 +8,6 @@ function getMultiplier() {
   return window.EasyPointsData.shop.multiplier * EasyPointsCore.Currency.getRate();
 }
 
-
 function formatBigNumber(int) {
   return int.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }

--- a/snippets/easy_points.liquid
+++ b/snippets/easy_points.liquid
@@ -1,13 +1,27 @@
-{%- assign shop_ep_metafield = shop.metafields.loyalty.easy_points_attributes.value -%}
+{%- liquid
+  assign shop_ep_metafield = shop.metafields.loyalty.easy_points_attributes.value
+  assign currency_multiplier = 100
+  if shop.currency == 'USD'
+    assign currency_multiplier = 1
+  endif
+-%}
 {%- unless shop_ep_metafield.stealth_mode -%}
   <div style="display: none !important;">
     <input type="hidden" id="shopDomain" name="shopDomain" value="{{ shop.domain }}">
     <input type="hidden" data-loyal-target="shop-point-rule-percent">
     <input type="hidden" data-loyal-target="shop-point-rule-point-value" value="{{ shop_ep_metafield.point_value }}">
-    <input type="hidden" data-loyal-target="shop-point-rule-currency-value" value="{{ shop_ep_metafield.currency_value }}">
+    <input
+      type="hidden"
+      data-loyal-target="shop-point-rule-currency-value"
+      value="{{ shop_ep_metafield.currency_value }}"
+    >
     <input type="hidden" data-loyal-target="shop-reward-percent">
     <input type="hidden" data-loyal-target="shop-reward-point-value" value="{{ shop_ep_metafield.reward_point_value }}">
-    <input type="hidden" data-loyal-target="shop-reward-currency-value" value="{{ shop_ep_metafield.reward_currency_value }}">
+    <input
+      type="hidden"
+      data-loyal-target="shop-reward-currency-value"
+      value="{{ shop_ep_metafield.reward_currency_value }}"
+    >
     {%- if shop.customer_accounts_enabled and customer -%}
       <input type="hidden" id="customerId" name="customerId" value="{{ customer.id }}">
       <input type="hidden" id="cart-total" name="cart-total" value="{{ cart.total_price }}">
@@ -20,8 +34,9 @@
       shop: {
         domain: "{{ shop.domain }}",
         locale: "{{ request.locale.iso_code }}",
+        multiplier: {{ currency_multiplier }},
         money_format: "{{ shop.money_format | strip_html | escape }}",
-        money_format_options: { convert: true, multiplier: 100 },
+        money_format_options: { convert: true, multiplier: {{ currency_multiplier }} },
         rules: {
           point: {
             percent: null,

--- a/snippets/easy_points.liquid
+++ b/snippets/easy_points.liquid
@@ -1,8 +1,12 @@
 {%- liquid
   assign shop_ep_metafield = shop.metafields.loyalty.easy_points_attributes.value
-  assign currency_multiplier = 100
-  if shop.currency == 'USD'
-    assign currency_multiplier = 1
+  assign currency_multiplier = 1
+
+  assign currencies = 'JPY,KRW,BIF,CLP,DJF,GNF,ISK,KMF,PYG,RWF,UGX,VND,VUV,XAF,XOF,XPF'
+  assign currencies = currencies | split: ','
+
+  if currencies contains shop.currency
+    assign currency_multiplier = 100
   endif
 -%}
 {%- unless shop_ep_metafield.stealth_mode -%}

--- a/snippets/easy_points_metafield_script.liquid
+++ b/snippets/easy_points_metafield_script.liquid
@@ -30,10 +30,8 @@
 
       if (typeof customerEpMetafield.coupon_value === "number" && customerEpMetafield.coupon_value > 0) {
         easyPointsSession.appliedDiscount = customerEpMetafield.coupon_value;
-        easyPointsSession.appliedDiscountCurrency = customerEpMetafield.coupon_currency;
       } else {
         delete easyPointsSession.appliedDiscount;
-        delete easyPointsSession.appliedDiscountCurrency;
       }
     } else {
       easyPointsSession.customerPointRulePercentage = parseInt(shopEpMetafield.percentage);
@@ -46,7 +44,6 @@
       delete easyPointsSession.rankMaintenanceData;
       delete easyPointsSession.rankAdvancementData;
       delete easyPointsSession.appliedDiscount;
-      delete easyPointsSession.appliedDiscountCurrency;
     }
 
     sessionStorage.setItem("easyPoints", JSON.stringify(easyPointsSession));

--- a/snippets/easy_points_taxable.liquid
+++ b/snippets/easy_points_taxable.liquid
@@ -7,7 +7,7 @@
     assign include_tax = customer_ep_metafield.include_tax
   endif
 
-  assign tax_rate = tax_rate | default: 1.0
+  assign tax_rate = tax_rate | default: 1.1
 
   if product
     for collection in product.collections

--- a/snippets/easy_points_taxable.liquid
+++ b/snippets/easy_points_taxable.liquid
@@ -51,24 +51,10 @@
 
 {%- if tax_price -%}
   {%- raw -%}
-  data-loyal-{%- endraw -%}
-  {{ key | default: 'currency-cost' }}
-  {%- raw -%}="{%- endraw -%}
-  {{ tax_price | floor }}
-  {%- raw -%}"
-  data-loyal-cost-original="{%- endraw -%}
-  {{ price }}
-  {%- raw -%}"
-  {%- endraw -%}
+  data-loyal-{%- endraw -%}{{ key | default: 'currency-cost' }}{%- raw -%}="{%- endraw -%}{{ tax_price | floor }}{%- raw -%}"
+  data-loyal-cost-original="{%- endraw -%}{{ price }}{%- raw -%}"
+{%- endraw -%}
 {%- endif -%}
 {%- raw -%}
-  data-loyal-opts="{&quot;tax&quot;: {&quot;rate&quot;: {%- endraw -%}
-{{ tax_rate }}
-{%- raw -%}, &quot;included&quot;: {%- endraw -%}
-{{ tax_included }}
-{%- raw -%}, &quot;exempt&quot;: {%- endraw -%}
-{{ tax_exempt }}
-{%- raw -%}, &quot;awardable&quot;: {%- endraw -%}
-{{ include_tax }}
-{%- raw -%}}}"
+  data-loyal-opts="{&quot;tax&quot;: {&quot;rate&quot;: {%- endraw -%}{{ tax_rate }}{%- raw -%}, &quot;included&quot;: {%- endraw -%}{{ tax_included }}{%- raw -%}, &quot;exempt&quot;: {%- endraw -%}{{ tax_exempt }}{%- raw -%}, &quot;awardable&quot;: {%- endraw -%}{{ include_tax }}{%- raw -%}}}"
 {%- endraw -%}

--- a/snippets/easy_points_taxable.liquid
+++ b/snippets/easy_points_taxable.liquid
@@ -51,9 +51,9 @@
 
 {%- if tax_price -%}
   {%- raw -%}
-  data-loyal-{%- endraw -%}{{ key | default: 'currency-cost' }}{%- raw -%}="{%- endraw -%}{{ tax_price | floor }}{%- raw -%}"
+  data-loyal-{%- endraw -%}{{ key | default: "currency-cost" }}{%- raw -%}="{%- endraw -%}{{ tax_price | floor }}{%- raw -%}"
   data-loyal-cost-original="{%- endraw -%}{{ price }}{%- raw -%}"
-{%- endraw -%}
+  {%- endraw -%}
 {%- endif -%}
 {%- raw -%}
   data-loyal-opts="{&quot;tax&quot;: {&quot;rate&quot;: {%- endraw -%}{{ tax_rate }}{%- raw -%}, &quot;included&quot;: {%- endraw -%}{{ tax_included }}{%- raw -%}, &quot;exempt&quot;: {%- endraw -%}{{ tax_exempt }}{%- raw -%}, &quot;awardable&quot;: {%- endraw -%}{{ include_tax }}{%- raw -%}}}"

--- a/snippets/easy_points_taxable.liquid
+++ b/snippets/easy_points_taxable.liquid
@@ -7,12 +7,12 @@
     assign include_tax = customer_ep_metafield.include_tax
   endif
 
-  assign tax_rate = tax_rate | default: 1.1
+  assign tax_rate = tax_rate | default: 1.0
 
   if product
     for collection in product.collections
-      if collection.metafields.loyalty['tax_override_percentage']
-        assign tax_override_percentage = collection.metafields.loyalty['tax_override_percentage']
+      if collection.metafields.loyalty.tax_override_percentage
+        assign tax_override_percentage = collection.metafields.loyalty.tax_override_percentage
         assign tax_override_percentage = tax_override_percentage | divided_by: 100
         assign tax_rate = 1 | plus: tax_override_percentage
       endif
@@ -51,10 +51,24 @@
 
 {%- if tax_price -%}
   {%- raw -%}
-  data-loyal-{%- endraw -%}{{ key | default: "currency-cost" }}{%- raw -%}="{%- endraw -%}{{ tax_price | floor }}{%- raw -%}"
-  data-loyal-cost-original="{%- endraw -%}{{ price }}{%- raw -%}"
+  data-loyal-{%- endraw -%}
+  {{ key | default: 'currency-cost' }}
+  {%- raw -%}="{%- endraw -%}
+  {{ tax_price | floor }}
+  {%- raw -%}"
+  data-loyal-cost-original="{%- endraw -%}
+  {{ price }}
+  {%- raw -%}"
   {%- endraw -%}
 {%- endif -%}
 {%- raw -%}
-  data-loyal-opts="{&quot;tax&quot;: {&quot;rate&quot;: {%- endraw -%}{{ tax_rate }}{%- raw -%}, &quot;included&quot;: {%- endraw -%}{{ tax_included }}{%- raw -%}, &quot;exempt&quot;: {%- endraw -%}{{ tax_exempt }}{%- raw -%}, &quot;awardable&quot;: {%- endraw -%}{{ include_tax }}{%- raw -%}}}"
+  data-loyal-opts="{&quot;tax&quot;: {&quot;rate&quot;: {%- endraw -%}
+{{ tax_rate }}
+{%- raw -%}, &quot;included&quot;: {%- endraw -%}
+{{ tax_included }}
+{%- raw -%}, &quot;exempt&quot;: {%- endraw -%}
+{{ tax_exempt }}
+{%- raw -%}, &quot;awardable&quot;: {%- endraw -%}
+{{ include_tax }}
+{%- raw -%}}}"
 {%- endraw -%}


### PR DESCRIPTION
# Description

Replace hardcoded multiplier values that are in the asset install boilerplate. Use recent Solaris conversion as an example.

Mentioned here: https://github.com/TeamLunaris/easypoints-integration-boilerplate/pull/23#issuecomment-1593409578

### Additional notes/thoughts

This PR was used to replace multiple hardcoded values in the Solaris Webstore.

Solaris PR: https://github.com/SolarisJapan/solaris-shopify-theme-v2/pull/294

## Checklist

- [x] **Read through PR once more**

## Testing

- [x] Test mobile view
- [x] Test on Chrome

[COR-74](https://linear.app/easypoints/issue/COR-74/asset-boilerplate-replace-hardcoded-multiplier-values)