### PR TITLE
fix: point exclusion product point display

### DIFF
--- a/assets/easy_points_integration.css
+++ b/assets/easy_points_integration.css
@@ -19,7 +19,7 @@
   color: var(--ep-color-points);
 }
 
-.easy-points [data-loyal-target="point-exclusion"] + .easy-points__text {
+/* .easy-points [data-loyal-target="point-exclusion"] + .easy-points__text {
   display: none;
 }
 
@@ -27,7 +27,7 @@
   [data-loyal-target="point-exclusion-product"]
   + .easy-points__text {
   display: none;
-}
+} */
 
 .easy-points__account {
   margin-bottom: var(--ep-spacer-3);

--- a/locales/en-ep.json
+++ b/locales/en-ep.json
@@ -1,5 +1,6 @@
 "easypoints": {
     "points": "Points",
+    "no_points": "No points will be rewarded",
     "points_earned": "Points Earned",
     "points_earned_total": "Points Earned",
     "points_balance": "Points Available",

--- a/locales/ja-ep.json
+++ b/locales/ja-ep.json
@@ -1,6 +1,7 @@
 
 "easypoints": {
     "points": "ポイント",
+    "no_points": "ポイント対象外",
     "points_earned": "ポイント\/円 還元",
     "points_earned_total": "獲得ポイント",
     "points_balance": "ポイント保有中",

--- a/snippets/easy_points_product_points.liquid
+++ b/snippets/easy_points_product_points.liquid
@@ -1,11 +1,10 @@
 {%- comment -%} START EASYPOINTS - DO NOT MODIFY! 変更しないでください! INFO @ https://bit.ly/2Dn7ESM {%- endcomment -%}
 {%- assign shop_ep_metafield = shop.metafields.loyalty.easy_points_attributes.value -%}
 {%- unless shop_ep_metafield.stealth_mode -%}
-  {%- assign class = class | default: 'easy-points easy-points__product-points' -%}
-  {%- assign style = style | default: 'easy-points__text easy-points__text--suffix' -%}
-  {%- assign text = text | default: 'easypoints.points' -%}
-
   {%- liquid
+    assign class = class | default: 'easy-points easy-points__product-points'
+    assign style = style | default: 'easy-points__text easy-points__text--suffix'
+    assign text = text | default: 'easypoints.points'
 
     assign current_product = product
     if item
@@ -21,7 +20,7 @@
         endif
       endfor
 
-      if worth_points 
+      if worth_points
         for collection in current_product.collections
           if collection.handle == 'easy-points-point-exclusion'
             assign worth_points = false
@@ -35,11 +34,11 @@
   <span class="{{ class }}">
     {% render 'easy_points_product_price_value', item: item, price: price, worth_points: worth_points %}
     {%- if worth_points == true -%}
-      <span class="style">
+      <span class="{{ style }}">
         {{ text | t }}
       </span>
     {%- else -%}
-      <span class="style">
+      <span class="{{ style }}">
         {{ 'easypoints.no_points' | t }}
       </span>
     {%- endif -%}

--- a/snippets/easy_points_product_points.liquid
+++ b/snippets/easy_points_product_points.liquid
@@ -1,15 +1,46 @@
 {%- comment -%} START EASYPOINTS - DO NOT MODIFY! 変更しないでください! INFO @ https://bit.ly/2Dn7ESM {%- endcomment -%}
-  {%- assign shop_ep_metafield = shop.metafields.loyalty.easy_points_attributes.value -%}
-  {%- unless shop_ep_metafield.stealth_mode -%}
-    {%- assign class = class | default: 'easy-points easy-points__product-points' -%}
-    {%- assign text = text | default: 'easypoints.points' -%}
+{%- assign shop_ep_metafield = shop.metafields.loyalty.easy_points_attributes.value -%}
+{%- unless shop_ep_metafield.stealth_mode -%}
+  {%- assign class = class | default: 'easy-points easy-points__product-points' -%}
+  {%- assign style = style | default: 'easy-points__text easy-points__text--suffix' -%}
+  {%- assign text = text | default: 'easypoints.points' -%}
 
-    <span class="{{ class }}">
-      {% render 'easy_points_product_price_value', item: item, price: price %}
-      <span class="easy-points__text easy-points__text--suffix">
+  {%- liquid
+
+    assign current_product = product
+    if item
+      assign current_product = item.product
+    endif
+
+    assign worth_points = true
+    if current_product
+      for collection in current_product.collections
+        if collection.handle == 'easy-points-point-exclusion' 
+          assign worth_points = false
+          break
+        else 
+          for tag in current_product.tags 
+            if tag == 'no-easy-points'
+              assign worth_points = false
+              break
+            endif
+          endfor
+        endif
+      endfor
+    endif
+  -%}
+
+  <span class="{{ class }}">
+    {% render 'easy_points_product_price_value', item: item, price: price %}
+    {%- if worth_points == true -%}
+      <span class="style">
         {{ text | t }}
       </span>
-    </span>
-  {%- endunless -%}
+    {%- else -%}
+      <span class="style">
+        {{ 'easypoints.no_points' | t }}
+      </span>
+    {%- endif -%}
+  </span>
+{%- endunless -%}
 {%- comment -%} END EASYPOINTS {%- endcomment -%}
-

--- a/snippets/easy_points_product_points.liquid
+++ b/snippets/easy_points_product_points.liquid
@@ -14,24 +14,26 @@
 
     assign worth_points = true
     if current_product
-      for collection in current_product.collections
-        if collection.handle == 'easy-points-point-exclusion' 
+      for tag in current_product.tags
+        if tag == 'no-easy-points'
           assign worth_points = false
           break
-        else 
-          for tag in current_product.tags 
-            if tag == 'no-easy-points'
-              assign worth_points = false
-              break
-            endif
-          endfor
         endif
       endfor
+
+      if worth_points 
+        for collection in current_product.collections
+          if collection.handle == 'easy-points-point-exclusion'
+            assign worth_points = false
+            break
+          endif
+        endfor
+      endif
     endif
   -%}
 
   <span class="{{ class }}">
-    {% render 'easy_points_product_price_value', item: item, price: price %}
+    {% render 'easy_points_product_price_value', item: item, price: price, worth_points: worth_points %}
     {%- if worth_points == true -%}
       <span class="style">
         {{ text | t }}

--- a/snippets/easy_points_product_price_value.liquid
+++ b/snippets/easy_points_product_price_value.liquid
@@ -11,6 +11,13 @@
         if collection.handle == 'easy-points-point-exclusion'
           assign worth_points = false
           break
+        else 
+         for tag in current_product.tags 
+            if tag == 'no-easy-points'
+              assign worth_points = false
+              break
+            endif
+          endfor
         endif
       endfor
     endif

--- a/snippets/easy_points_product_price_value.liquid
+++ b/snippets/easy_points_product_price_value.liquid
@@ -1,6 +1,6 @@
 {%- comment -%} START EASYPOINTS - DO NOT MODIFY! 変更しないでください! INFO @ https://bit.ly/2Dn7ESM {%- endcomment -%}
   {%- liquid
-    assign worth_points = worth_points
+    assign worth_points = worth_points | default: true
     assign current_product = product
     if item
       assign current_product = item.product

--- a/snippets/easy_points_product_price_value.liquid
+++ b/snippets/easy_points_product_price_value.liquid
@@ -1,25 +1,9 @@
 {%- comment -%} START EASYPOINTS - DO NOT MODIFY! 変更しないでください! INFO @ https://bit.ly/2Dn7ESM {%- endcomment -%}
   {%- liquid
+    assign worth_points = worth_points
     assign current_product = product
     if item
       assign current_product = item.product
-    endif
-
-    assign worth_points = true
-    if current_product
-      for collection in current_product.collections
-        if collection.handle == 'easy-points-point-exclusion'
-          assign worth_points = false
-          break
-        else 
-         for tag in current_product.tags 
-            if tag == 'no-easy-points'
-              assign worth_points = false
-              break
-            endif
-          endfor
-        endif
-      endfor
     endif
   -%}
 


### PR DESCRIPTION
- added a fallback condition with `no-easy-points` tags for products in point exclusion collection

- show a default text that says the product is excluded from point rewards

- commented out the default CSS that targets [point-exclusion-product] to display none by default