### PR TITLE
feat: use `<epi-redemption-form>`

### DIFF
--- a/assets/easy_points_integration.js
+++ b/assets/easy_points_integration.js
@@ -807,8 +807,10 @@ var EasyPoints = {
       EasyPoints.sdk().updateLoyaltyTargets();
       EasyPoints.Tiers.recalculate();
 
-      this.setEventListeners();
-      EasyPoints.showDiscountUI();
+      // Handled by the `<epi-redemption-form>` component
+      // (uncomment lines below if not using the component)
+      // this.setEventListeners();
+      // EasyPoints.showDiscountUI();
     },
 
     /**

--- a/assets/easy_points_integration.js
+++ b/assets/easy_points_integration.js
@@ -822,12 +822,12 @@ var EasyPoints = {
     /**
      * Set up the necessary event listeners for redeeming points and resetting the form.
      */
-    setEventListeners: function() {
-      if (EasyPoints.Selectors.getRedeemContainerEl(document, true).length == 0) {
+    setEventListeners: function(el = document) {
+      if (EasyPoints.Selectors.getRedeemContainerEl(el, true).length == 0) {
         return;
       }
 
-      EasyPoints.Selectors.getRedeemPointsInputEl(document, true)
+      EasyPoints.Selectors.getRedeemPointsInputEl(el, true)
         .forEach(node => {
           node.addEventListener('focus', this.onPointsInput);
 
@@ -836,10 +836,10 @@ var EasyPoints = {
           }
         });
 
-      EasyPoints.Selectors.getRedeemPointsButtonEl(document, true)
+      EasyPoints.Selectors.getRedeemPointsButtonEl(el, true)
         .forEach(node => node.addEventListener('click', this.onClickRedeemBtn));
 
-      EasyPoints.Selectors.getResetPointsButtonEl(document, true)
+      EasyPoints.Selectors.getResetPointsButtonEl(el, true)
         .forEach(node => node.addEventListener('click', this.onClickResetBtn));
 
       EasyPoints.Debug.print('Applied all required event listeners');

--- a/snippets/easy_points_redemption.liquid
+++ b/snippets/easy_points_redemption.liquid
@@ -2,8 +2,10 @@
   {%- assign shop_ep_metafield = shop.metafields.loyalty.easy_points_attributes.value -%}
   {%- unless shop_ep_metafield.stealth_mode -%}
     {%- if customer -%}
-      {%- assign customer_ep_metafield = customer.metafields.loyalty.easy_points_attributes.value -%}
-      {% assign class_button = class_button | default: 'button' %}
+      {%- liquid
+        assign customer_ep_metafield = customer.metafields.loyalty.easy_points_attributes.value
+        assign class_button = class_button | default: 'button'
+      -%}
       <epi-redemption-form>
         <div class="easy-points-form__container">
           <div class="easy-points-form__balance">

--- a/snippets/easy_points_redemption.liquid
+++ b/snippets/easy_points_redemption.liquid
@@ -4,25 +4,27 @@
     {%- if customer -%}
       {%- assign customer_ep_metafield = customer.metafields.loyalty.easy_points_attributes.value -%}
       {% assign class_button = class_button | default: 'button' %}
-      <div class="easy-points-form__container">
-        <div class="easy-points-form__balance">
-          <span data-loyal-target="balance">{{ customer_ep_metafield.balance }}</span> {{ 'easypoints.points_balance' | t }}
-        </div>
-        <div class="easy-points-form__inner">
-          <div class="easy-points-form__input">
-            <div class="easy-points-form__discount hidden-unless-discount-applied easy-points-hide">
-              -&nbsp;<span data-loyal-target="applied-discount"></span>
-            </div>
-            <input type="number" name="redemption_point_value" min="0" autocomplete="off">
+      <epi-redemption-form>
+        <div class="easy-points-form__container">
+          <div class="easy-points-form__balance">
+            <span data-loyal-target="balance">{{ customer_ep_metafield.balance }}</span> {{ 'easypoints.points_balance' | t }}
           </div>
-          <button class="easy-points-button__redeem {{ class_button }}" type="button">
-            {{ 'easypoints.cart_redeem' | t }}
-          </button>
-          <button class="easy-points-button__reset {{ class_button }} easy-points-hide" type="button">
-            {{ 'easypoints.cart_reset' | t }}
-          </button>
+          <div class="easy-points-form__inner">
+            <div class="easy-points-form__input">
+              <div class="easy-points-form__discount hidden-unless-discount-applied easy-points-hide">
+                -&nbsp;<span data-loyal-target="applied-discount"></span>
+              </div>
+              <input type="number" name="redemption_point_value" min="0" autocomplete="off">
+            </div>
+            <button class="easy-points-button__redeem {{ class_button }}" type="button">
+              {{ 'easypoints.cart_redeem' | t }}
+            </button>
+            <button class="easy-points-button__reset {{ class_button }} easy-points-hide" type="button">
+              {{ 'easypoints.cart_reset' | t }}
+            </button>
+          </div>
         </div>
-      </div>
+      </epi-redemption-form>
     {%- endif -%}
   {%- endunless -%}
 {%- comment -%} END EASYPOINTS {%- endcomment -%}


### PR DESCRIPTION
Should simplify re-renders and messing with listeners for the redemption form (requires the latest sdk, **not deployed yet**)